### PR TITLE
add "-std=c++11" for clang on macOS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ from setuptools import setup, find_packages, Extension
 from glob import glob
 import pybind11
 import os
+import sys
 
 
 ext_modules = [
@@ -15,6 +16,8 @@ ext_modules = [
         extra_compile_args=["-Ofast"])
 ]
 
+if sys.platform == "darwin":
+    ext_modules[0].extra_compile_args.append("-std=c++11")
 
 setup(
     name="graph-walker",


### PR DESCRIPTION
Add the compile parameters to make clang use C++11 on macOS.