### PR TITLE
add pyproject.toml with [build-system] section to be compliant with PEP-518

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "pybind11"]


### PR DESCRIPTION
I was trying to install the package using pdm package manager, but I was getting the error `ModuleNotFoundError: No module named 'pybind11'` even if I had done `pdm add pybind11` before. 

Reading further above in the trace-back I found this message:

```
pdm.exceptions.BuildError: Build backend raised error: Module 'pybind11' is missing, please make sure it is specified in
the 'build-system.requires' section. If it is not possible, add it to the project and use '--no-isolation' option.
Showing the last 10 lines of the build output:
    return self._get_build_requires(config_settings, requirements=['wheel'])
```

By adding the pyproject.toml as done in [this PR of fastText](https://github.com/facebookresearch/fastText/pull/1292) I managed to solve the issue. 

I can now install the package doing: `pdm add "graph-walker @ git+https://github.com/pacorofe/graph-walker"`. So ideally this would be merged and a new version would be released. 

Note that by adding this change one does not need to install `pybind11` before installing the package. 